### PR TITLE
Server proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -759,6 +759,10 @@
       "resolved": "package/core",
       "link": true
     },
+    "node_modules/@the-bds-maneger/server_proxy": {
+      "resolved": "package/proxy",
+      "link": true
+    },
     "node_modules/@the-bds-maneger/web": {
       "resolved": "package/web",
       "link": true
@@ -6730,6 +6734,10 @@
       "devDependencies": {
         "@types/express": "^4.17.17"
       }
+    },
+    "package/proxy": {
+      "version": "0.0.1",
+      "license": "GPL-2.0-only"
     },
     "package/web": {
       "name": "@the-bds-maneger/web",

--- a/package/proxy/package.json
+++ b/package/proxy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@the-bds-maneger/server_proxy",
+  "version": "0.0.1",
+  "description": "Host multiples server ports and publish one port to internet",
+  "main": "src/index.js",
+  "scripts": {
+    "build": "tsc --build --clean && tsc"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Sirherobrine23/Bds-Maneger.git"
+  },
+  "keywords": [
+    "proxy"
+  ],
+  "author": "Matheus Sampaio Queiroga <srherobrine20@gmail.com>",
+  "license": "GPL-2.0-only",
+  "bugs": {
+    "url": "https://github.com/Sirherobrine23/Bds-Maneger/issues"
+  },
+  "homepage": "https://github.com/Sirherobrine23/Bds-Maneger#readme"
+}

--- a/package/proxy/tsconfig.json
+++ b/package/proxy/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {}
+}


### PR DESCRIPTION
Hóspede vários servidores de forma rápida com domínios wildcard e de forma que consiga hospedar "uma" porta padrão para que vários clientes conectem em apenas uma porta e o proxy redirecionar para o servidor hospedado localmente com outra porta.

## TODO

- [ ] Bedrock proxy
- [ ] Java Proxy